### PR TITLE
Update documentation to English and remove sensitive environment details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,117 @@
+# Appointment Management App
+
+Full-stack application to manage appointments with authentication, service management, and user scheduling. The project is split into a **backend** (Node.js/Express REST API) and a **frontend** (Vue 3 + Vite SPA).
+
+## Table of Contents
+- [Features](#features)
+- [Tech Stack](#tech-stack)
+- [Project Structure](#project-structure)
+- [Prerequisites](#prerequisites)
+- [Getting Started](#getting-started)
+  - [Backend](#backend)
+  - [Frontend](#frontend)
+- [Helpful Scripts](#helpful-scripts)
+- [Main Endpoints](#main-endpoints)
+
+## Features
+- Sign up and login with JWT.
+- Account confirmation and password recovery via email.
+- Service management (CRUD).
+- Appointment management (create, update, delete, query by date).
+- User appointment overview.
+
+## Tech Stack
+**Backend**
+- Node.js, Express, MongoDB (Mongoose)
+- JWT authentication
+- Nodemailer for email notifications
+
+**Frontend**
+- Vue 3 + Vite
+- Pinia for state management
+- Tailwind CSS and FormKit for UI
+
+## Project Structure
+```
+.
+├── backend
+│   ├── config
+│   ├── controllers
+│   ├── data
+│   ├── emails
+│   ├── middelware
+│   ├── models
+│   ├── routes
+│   ├── utils
+│   └── index.js
+└── frontend
+    ├── public
+    └── src
+```
+
+## Prerequisites
+- Node.js (recommended >= 20)
+- MongoDB running locally or remotely
+- An SMTP provider for transactional emails
+
+## Getting Started
+### Backend
+```bash
+cd backend
+npm install
+npm run dev
+```
+
+The API will be available at `http://localhost:8000` (or the port you configure).
+
+### Frontend
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The app will be available at `http://localhost:5173` by default.
+
+## Helpful Scripts
+**Backend**
+- `npm run dev`: start server with reload
+- `npm run dev:postman`: allow requests without a defined origin
+- `npm run seed:import`: load seed data
+- `npm run seed:destroy`: remove seed data
+
+**Frontend**
+- `npm run build`: production build
+- `npm run preview`: preview production build
+- `npm run lint`: lint + fix
+- `npm run format`: format with Prettier
+
+## Main Endpoints
+Base URL: `/api`
+
+- **Auth**
+  - `POST /auth/sign-up`
+  - `GET /auth/confirm-account/:token`
+  - `POST /auth/login`
+  - `POST /auth/forgot-password`
+  - `GET /auth/new-password/:token`
+  - `POST /auth/new-password/:token`
+  - `GET /auth/user` (JWT required)
+  - `GET /auth/admin` (JWT required)
+
+- **Services**
+  - `GET /services`
+  - `POST /services`
+  - `GET /services/:id`
+  - `PUT /services/:id`
+  - `DELETE /services/:id`
+
+- **Appointments** (JWT required)
+  - `POST /appointments`
+  - `GET /appointments?date=YYYY-MM-DD`
+  - `GET /appointments/:id`
+  - `PUT /appointments/:id`
+  - `DELETE /appointments/:id`
+
+- **Users** (JWT required)
+  - `GET /users/:user/appointments`

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,35 +1,15 @@
-# frontend
+# Frontend - Appointment Management App
 
-This template should help get you started developing with Vue 3 in Vite.
+SPA client built with **Vue 3 + Vite**. For full project documentation (setup, scripts, and API overview), see the main README in the repository root.
 
-## Recommended IDE Setup
-
-[VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and disable Vetur).
-
-## Customize configuration
-
-See [Vite Configuration Reference](https://vite.dev/config/).
-
-## Project Setup
-
+## Scripts
 ```sh
 npm install
-```
-
-### Compile and Hot-Reload for Development
-
-```sh
 npm run dev
 ```
 
-### Compile and Minify for Production
-
-```sh
-npm run build
-```
-
-### Lint with [ESLint](https://eslint.org/)
-
-```sh
-npm run lint
-```
+Other available commands:
+- `npm run build`
+- `npm run preview`
+- `npm run lint`
+- `npm run format`


### PR DESCRIPTION
### Motivation
- Provide clear English documentation for the project to improve onboarding and consistency across the repo. 
- Remove any explicit `.env` or sensitive configuration examples to avoid exposing values that could endanger the site.

### Description
- Rewrote the root `README.md` in English and removed the explicit environment variable examples while preserving setup instructions, scripts, and endpoint references. 
- Updated `frontend/README.md` to an English, minimal client README that references the main README and lists common scripts.

### Testing
- No automated tests were run because the changes are documentation-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b5365a4bc832e8d239ec246af4b7f)